### PR TITLE
Fix extraCommonDirNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
+# Intro
 The set of Danger.js rules commonly applied in [OttoFeller](https://ottofeller.com).
+
+# Local development and testing
+
+1. Clone this repository to your local machine
+```
+git clone git@github.com:ottofeller/dangerules.git
+```
+
+2. Go to the repo folder and create global npm link
+```
+cd dangerules
+npm link
+```
+
+3. Go to the project you want to test danger on
+```
+cd test-project
+```
+
+4. Link dangerules
+```
+test-project git(dev): npm link dangerules
+```
+
+5. In the test project, create a new branch, make changes and commit them
+
+6. Run the danger to check the current branch relative to the dev branch
+```
+test-project git(test-branch): npx danger local --dangerfile=./dangerfile.ts -b dev
+
+```
+
+Now you can make changes in the dangerules, which will be available after running the `npm run build`. Run `npm danger ...` in the project again for tests.

--- a/src/common-code-dir/index.ts
+++ b/src/common-code-dir/index.ts
@@ -66,7 +66,7 @@ export const commonCodeDir = (params: {
 
         !R.any(
           R.includes(R.__, innerPath),
-          R.append('/common/', R.map(dirName => `/${dirName}/`.replace(/\/\//, '/'), params.extraCommonDirNames || [])),
+          R.append('/common/', params.extraCommonDirNames || []),
         ),
       ),
 
@@ -100,11 +100,9 @@ export const commonCodeDir = (params: {
       R.flatten,
 
       // Find all js/jsx/ts/tsx files (including nested ones) in a dir
-      // Exclude unit tests or types, their imports should not be considered as common
+      // Exclude unit tests, their imports should not be considered as common
       R.map(includePath => R.filter(
-        innerPath => !R.isEmpty(R.match(/(js|jsx|ts|tsx)$/i, innerPath)) &&
-          R.isEmpty(R.match(/__tests__|types/i, innerPath)),
-
+        innerPath => !R.isEmpty(R.match(/(js|jsx|ts|tsx)$/i, innerPath)) && R.isEmpty(R.match(/__tests__/i, innerPath)),
         readdirNested({allFoundFiles: [], path: includePath}),
       )),
     )(params.includePaths)),


### PR DESCRIPTION
## Bug description
Danger sends false-positive messages that the `types` folder should me moved to the `common` folder.

`commonCodeDir` has a `extraCommonDirNames` argument. As I understand it, this parameter is intended to pass the list of dir names from which the import should follow to the same rules as the import from the `common` dir.

The issue is that when we pass `['/types']` in the parameter, an additional slash is added to the directory name, so it becomes `/types/`. When exporting from the `types` dir, the `index.ts` files is used so import path look like `/src/bin/validate-credit/types` (there is no slash at the end of the path).

## Bug fixing
Remove 
```js
`/${dirName}/`.replace(/\/\//, '/')
```
and use `extraCommonDirNames` as is.