### PR TITLE
Add rule for checking Hasura migrations

### DIFF
--- a/jest.tsconfig.json
+++ b/jest.tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "esnext",
-    "sourceMap": false,
+    "sourceMap": true,
     "experimentalDecorators": true,
     "noImplicitUseStrict": true,
     "removeComments": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
       "dependencies": {
         "@babel/parser": "7.17.3",
         "@types/ramda": "0.27.64",
-        "danger": "11.0.2",
+        "danger": ">=11.0.2",
         "ramda": "0.28.0"
       },
       "devDependencies": {
-        "@ottofeller/eslint-config-ofmt": "1.3.3",
-        "@ottofeller/ofmt": "1.3.3",
-        "@ottofeller/prettier-config-ofmt": "1.3.3",
+        "@ottofeller/eslint-config-ofmt": "1.3.6",
+        "@ottofeller/ofmt": "1.3.6",
+        "@ottofeller/prettier-config-ofmt": "1.3.6",
         "@rollup/plugin-commonjs": "21.0.1",
         "@rollup/plugin-node-resolve": "13.1.3",
         "@rollup/plugin-typescript": "8.3.0",
@@ -1513,9 +1513,9 @@
       }
     },
     "node_modules/@ottofeller/eslint-config-ofmt": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ottofeller/eslint-config-ofmt/-/eslint-config-ofmt-1.3.3.tgz",
-      "integrity": "sha512-MfC/Pocc6V0UCPvwICUdCmAk+2G+dQvwR2VEmqUa/GvJCHRsWX3wQ+OTAMLq5PILoNQqSUEQ/pt94lXz48F5Gg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@ottofeller/eslint-config-ofmt/-/eslint-config-ofmt-1.3.6.tgz",
+      "integrity": "sha512-MqJYTqbJC3VtejJyb4rw8QPA8x4ZiAp4TA8b0BrouoHO6dLWV6DKeaUvII1LnHLH/aWY5VU4B/DfotUBCFIoZg==",
       "dev": true,
       "dependencies": {
         "@ottofeller/eslint-plugin-ottofeller": "0.1.3",
@@ -1549,9 +1549,9 @@
       }
     },
     "node_modules/@ottofeller/ofmt": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ottofeller/ofmt/-/ofmt-1.3.3.tgz",
-      "integrity": "sha512-dNSLxdrbuhZ5one9vAdkuTHNzQoBf7y55ncAiHa6Y3g1Xy7RNO3Eet8Fd6IQcjZWrC6cJl94MDdSNsOxmd31vQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@ottofeller/ofmt/-/ofmt-1.3.6.tgz",
+      "integrity": "sha512-g6SGg91DvjwZxPbO6/hUqmu/JEOskfLBMEUuUuPQt9iWrGjbTWLSerIk1msKafr7pb3V1DTbV7GFG0D3nlYMaA==",
       "dev": true,
       "dependencies": {
         "@ottofeller/eslint-config-ofmt": ">= 1",
@@ -1579,9 +1579,9 @@
       }
     },
     "node_modules/@ottofeller/prettier-config-ofmt": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ottofeller/prettier-config-ofmt/-/prettier-config-ofmt-1.3.3.tgz",
-      "integrity": "sha512-ZMV7Nm0Vq3my24YWyKFP0+sQp3q8tQp3ONXRufA2Qum69tOtJN3yqqfAicmUUdAKyivpi9GRE8cPJQMSPfdAag==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@ottofeller/prettier-config-ofmt/-/prettier-config-ofmt-1.3.6.tgz",
+      "integrity": "sha512-WGlwhi5YdixdRRQulxC0RKdAI8yZOCcy7WT4l2faoYE4PrKsL0nEO69B6b3ToxNc6luYkusPC64rR1yeeji/Iw==",
       "dev": true
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -10821,9 +10821,9 @@
       }
     },
     "@ottofeller/eslint-config-ofmt": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ottofeller/eslint-config-ofmt/-/eslint-config-ofmt-1.3.3.tgz",
-      "integrity": "sha512-MfC/Pocc6V0UCPvwICUdCmAk+2G+dQvwR2VEmqUa/GvJCHRsWX3wQ+OTAMLq5PILoNQqSUEQ/pt94lXz48F5Gg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@ottofeller/eslint-config-ofmt/-/eslint-config-ofmt-1.3.6.tgz",
+      "integrity": "sha512-MqJYTqbJC3VtejJyb4rw8QPA8x4ZiAp4TA8b0BrouoHO6dLWV6DKeaUvII1LnHLH/aWY5VU4B/DfotUBCFIoZg==",
       "dev": true,
       "requires": {
         "@ottofeller/eslint-plugin-ottofeller": "0.1.3",
@@ -10847,9 +10847,9 @@
       }
     },
     "@ottofeller/ofmt": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ottofeller/ofmt/-/ofmt-1.3.3.tgz",
-      "integrity": "sha512-dNSLxdrbuhZ5one9vAdkuTHNzQoBf7y55ncAiHa6Y3g1Xy7RNO3Eet8Fd6IQcjZWrC6cJl94MDdSNsOxmd31vQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@ottofeller/ofmt/-/ofmt-1.3.6.tgz",
+      "integrity": "sha512-g6SGg91DvjwZxPbO6/hUqmu/JEOskfLBMEUuUuPQt9iWrGjbTWLSerIk1msKafr7pb3V1DTbV7GFG0D3nlYMaA==",
       "dev": true,
       "requires": {
         "@ottofeller/eslint-config-ofmt": ">= 1",
@@ -10869,9 +10869,9 @@
       }
     },
     "@ottofeller/prettier-config-ofmt": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@ottofeller/prettier-config-ofmt/-/prettier-config-ofmt-1.3.3.tgz",
-      "integrity": "sha512-ZMV7Nm0Vq3my24YWyKFP0+sQp3q8tQp3ONXRufA2Qum69tOtJN3yqqfAicmUUdAKyivpi9GRE8cPJQMSPfdAag==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@ottofeller/prettier-config-ofmt/-/prettier-config-ofmt-1.3.6.tgz",
+      "integrity": "sha512-WGlwhi5YdixdRRQulxC0RKdAI8yZOCcy7WT4l2faoYE4PrKsL0nEO69B6b3ToxNc6luYkusPC64rR1yeeji/Iw==",
       "dev": true
     },
     "@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@ottofeller/eslint-config-ofmt": "1.3.3",
-    "@ottofeller/ofmt": "1.3.3",
-    "@ottofeller/prettier-config-ofmt": "1.3.3",
+    "@ottofeller/eslint-config-ofmt": "1.3.6",
+    "@ottofeller/ofmt": "1.3.6",
+    "@ottofeller/prettier-config-ofmt": "1.3.6",
     "@rollup/plugin-commonjs": "21.0.1",
     "@rollup/plugin-node-resolve": "13.1.3",
     "@rollup/plugin-typescript": "8.3.0",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@babel/parser": "7.17.3",
     "@types/ramda": "0.27.64",
-    "danger": "11.0.2",
+    "danger": ">=11.0.2",
     "ramda": "0.28.0"
   },
   "peerDependencies": {

--- a/src/hasura/__tests__/index.ts
+++ b/src/hasura/__tests__/index.ts
@@ -1,6 +1,9 @@
-import {DangerDSLType} from 'danger'
+import {DangerDSLType, MarkdownString} from 'danger'
+import {readFileSync} from 'fs'
 import * as R from 'ramda'
-import {codegenMissing, squashMigrations} from '../index'
+import {codegenMissing, squashMigrations, migrationTableChange} from '../index'
+
+jest.mock('fs')
 
 describe('Hasura rules', () => {
   describe('Squash migrations', () => {
@@ -202,6 +205,133 @@ describe('Hasura rules', () => {
       })
 
       expect(warnMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Table change rule', () => {
+    const warnMock = jest.fn<void, [message: MarkdownString, file?: string, line?: number]>()
+    const mockedReadFileSync = readFileSync as unknown as jest.Mock<
+      string,
+      [path: string, options: {encoding: BufferEncoding; flag?: string | undefined} | BufferEncoding]
+    >
+    const dangerMock = (editedFiles?: string[]) =>
+      ({
+        git: {
+          fileMatch: () => ({
+            edited: !!editedFiles && editedFiles.length > 0,
+            getKeyedPaths: () => ({edited: editedFiles || []}),
+          }),
+        },
+      } as DangerDSLType)
+
+    afterEach(() => {
+      warnMock.mockClear()
+      mockedReadFileSync.mockClear()
+    })
+
+    afterAll(() => {
+      warnMock.mockReset()
+      mockedReadFileSync.mockReset()
+    })
+
+    it('does nothing if no migration files are edited', () => {
+      migrationTableChange({
+        danger: dangerMock(),
+        hasuraMigrationsPath: 'hasura/migrations',
+        warn: warnMock,
+      })
+
+      expect(warnMock).toHaveBeenCalledTimes(0)
+    })
+
+    it('does not warn if no breaking changes introduced', () => {
+      mockedReadFileSync.mockReturnValue('CREATE TABLE users; ALTER TABLE users ADD COLUMN address;')
+
+      migrationTableChange({
+        danger: dangerMock(['hasura/migrations/1/up']),
+        hasuraMigrationsPath: 'hasura/migrations',
+        warn: warnMock,
+      })
+
+      expect(warnMock).toHaveBeenCalledTimes(0)
+    })
+
+    it('warns if a field is renamed', () => {
+      mockedReadFileSync.mockReturnValue('ALTER TABLE users RENAME COLUMN name; ALTER TABLE users ADD COLUMN address;')
+
+      migrationTableChange({
+        danger: dangerMock(['hasura/migrations/1/up']),
+        hasuraMigrationsPath: 'hasura/migrations',
+        warn: warnMock,
+      })
+
+      expect(warnMock).toHaveBeenCalledTimes(1)
+      expect(warnMock).toHaveBeenCalledWith('Found Hasura migration renaming a field', 'hasura/migrations/1/up')
+    })
+
+    it('warns if a field is removed', () => {
+      mockedReadFileSync.mockReturnValue('ALTER TABLE users DROP COLUMN name; ALTER TABLE users ADD COLUMN address;')
+
+      migrationTableChange({
+        danger: dangerMock(['hasura/migrations/1/up']),
+        hasuraMigrationsPath: 'hasura/migrations',
+        warn: warnMock,
+      })
+
+      expect(warnMock).toHaveBeenCalledTimes(1)
+      expect(warnMock).toHaveBeenCalledWith('Found Hasura migration removing a field', 'hasura/migrations/1/up')
+    })
+
+    it('warns if an existing field has acquired a "NOT NULL" constraint', () => {
+      mockedReadFileSync.mockReturnValue(
+        'ALTER TABLE users ADD COLUMN address; ALTER TABLE users ALTER COLUMN address DROP NOT NULL;',
+      )
+
+      migrationTableChange({
+        danger: dangerMock(['hasura/migrations/1/up']),
+        hasuraMigrationsPath: 'hasura/migrations',
+        warn: warnMock,
+      })
+
+      expect(warnMock).toHaveBeenCalledTimes(1)
+      expect(warnMock).toHaveBeenCalledWith(
+        'Found Hasura migration removing "NOT NULL" constraint',
+        'hasura/migrations/1/up',
+      )
+    })
+
+    it('warns only for files with undesirable changes', () => {
+      mockedReadFileSync.mockImplementation(
+        (path: string) =>
+          ({
+            'hasura/migrations/1/up':
+              'CREATE TABLE users; ALTER TABLE users ADD COLUMN name; ALTER TABLE users ADD address Integer NOT NULL DEFAULT "0";',
+            'hasura/migrations/2/up': 'ALTER TABLE users ALTER COLUMN address DROP NOT NULL;',
+            'hasura/migrations/3/up': 'ALTER TABLE users DROP COLUMN address; ALTER TABLE users DROP COLUMN name;',
+            'hasura/migrations/4/up': 'ALTER TABLE users ADD COLUMN name;',
+          }[path] || ''),
+      )
+
+      migrationTableChange({
+        danger: dangerMock([
+          'src/index.tsx',
+          'hasura/migrations/1/up',
+          'hasura/migrations/2/up',
+          'hasura/migrations/3/up',
+          'hasura/migrations/4/up',
+        ]),
+        hasuraMigrationsPath: 'hasura/migrations',
+        warn: warnMock,
+      })
+
+      expect(warnMock).toHaveBeenCalledTimes(3)
+      expect(warnMock).toHaveBeenNthCalledWith(
+        1,
+        'Found Hasura migration removing "NOT NULL" constraint',
+        'hasura/migrations/2/up',
+      )
+      expect(warnMock).toHaveBeenNthCalledWith(2, 'Found Hasura migration removing a field', 'hasura/migrations/3/up')
+      expect(warnMock).toHaveBeenNthCalledWith(3, 'Found Hasura migration removing a field', 'hasura/migrations/3/up')
     })
   })
 })

--- a/src/hasura/__tests__/index.ts
+++ b/src/hasura/__tests__/index.ts
@@ -328,6 +328,22 @@ describe('Hasura rules', () => {
       expect(warnMock).toHaveBeenCalledWith('Found Hasura migration adding a primary key', 'hasura/migrations/1/up')
     })
 
+    it('warns if an undesirable change is introduced into a view or a materialized view', () => {
+      mockedReadFileSync.mockReturnValue(
+        'ALTER VIEW users RENAME COLUMN name; ALTER MATERIALIZED VIEW users RENAME COLUMN name;',
+      )
+
+      migrationTableChange({
+        danger: dangerMock(['hasura/migrations/1/up']),
+        hasuraMigrationsPath: 'hasura/migrations',
+        warn: warnMock,
+      })
+
+      expect(warnMock).toHaveBeenCalledTimes(2)
+      expect(warnMock).nthCalledWith(1, 'Found Hasura migration renaming a field', 'hasura/migrations/1/up')
+      expect(warnMock).nthCalledWith(2, 'Found Hasura migration renaming a field', 'hasura/migrations/1/up')
+    })
+
     it('warns only for files with undesirable changes', () => {
       mockedReadFileSync.mockImplementation(
         (path: string) =>

--- a/src/hasura/__tests__/index.ts
+++ b/src/hasura/__tests__/index.ts
@@ -328,6 +328,23 @@ describe('Hasura rules', () => {
       expect(warnMock).toHaveBeenCalledWith('Found Hasura migration adding a primary key', 'hasura/migrations/1/up')
     })
 
+    it('warns if a unique constrained is added', () => {
+      mockedReadFileSync.mockReturnValue(`
+        ALTER TABLE users ADD CONSTRAINT name_address UNIQUE (name, address);
+        ALTER TABLE users ADD CONSTRAINT users_pkey PRIMARY KEY USING INDEX uuid;'
+      `)
+
+      migrationTableChange({
+        danger: dangerMock(['hasura/migrations/1/up']),
+        hasuraMigrationsPath: 'hasura/migrations',
+        warn: warnMock,
+      })
+
+      expect(warnMock).toHaveBeenCalledTimes(2)
+      expect(warnMock).nthCalledWith(1, 'Found Hasura migration adding a unique constraint', 'hasura/migrations/1/up')
+      expect(warnMock).nthCalledWith(2, 'Found Hasura migration adding a unique constraint', 'hasura/migrations/1/up')
+    })
+
     it('warns if an undesirable change is introduced into a view or a materialized view', () => {
       mockedReadFileSync.mockReturnValue(
         'ALTER VIEW users RENAME COLUMN name; ALTER MATERIALIZED VIEW users RENAME COLUMN name;',

--- a/src/hasura/index.ts
+++ b/src/hasura/index.ts
@@ -1,2 +1,3 @@
 export * from './codegen-missing'
+export * from './migration-table-change'
 export * from './squash-migrations'

--- a/src/hasura/migration-table-change.ts
+++ b/src/hasura/migration-table-change.ts
@@ -1,0 +1,62 @@
+import {DangerDSLType, MarkdownString} from 'danger'
+import * as fs from 'fs'
+import * as R from 'ramda'
+
+/**
+ * Searches for Hasura migrations in edited files.
+ * If present, warns in case of:
+ * - rename of a field;
+ * - removal of a field;
+ * - "not null" restrictions on the existing field.
+ *
+ * @param danger Danger instance
+ * @param warn Danger warn function
+ * @param hasuraMigrationsPath paths to Hasura migrations
+ */
+export const migrationTableChange = (params: {
+  danger: DangerDSLType
+  hasuraMigrationsPath: string
+  warn: (message: MarkdownString, file?: string, line?: number) => void
+}) => {
+  const {danger, hasuraMigrationsPath, warn} = params
+  const hasuraMigrationsFiles = danger.git.fileMatch(`${hasuraMigrationsPath}/**/*`)
+
+  if (!hasuraMigrationsFiles.edited) {
+    return
+  }
+
+  R.forEach(
+    (filePath) =>
+      R.compose<[string], string, string[], string[], string[], void>(
+        R.forEach((statement) => {
+          const isAlterTableStatement = /^ALTER TABLE/.test(statement)
+          if (!isAlterTableStatement) {
+            return
+          }
+
+          const isRenameColumnStatement = /RENAME COLUMN/.test(statement)
+          if (isRenameColumnStatement) {
+            warn('Found Hasura migration renaming a field', filePath)
+            return
+          }
+
+          const isRemoveColumnStatement = /DROP COLUMN/.test(statement)
+          if (isRemoveColumnStatement) {
+            warn('Found Hasura migration removing a field', filePath)
+            return
+          }
+
+          const isRemoveNotNullConstraint = /ALTER COLUMN .+ DROP NOT NULL/.test(statement)
+          if (isRemoveNotNullConstraint) {
+            warn('Found Hasura migration removing "NOT NULL" constraint', filePath)
+          }
+        }),
+        R.map(R.compose(R.toUpper, R.trim)),
+        // @ts-expect-error -- TS mistakenly identify "R.identity" type as "<T>(val: T): val is T" instead of "<T>(val: T): T"
+        R.filter<string, string>(R.identity),
+        R.split(';'),
+        R.curryN(2, R.flip(fs.readFileSync))({encoding: 'utf-8'}),
+      )(filePath),
+    hasuraMigrationsFiles.getKeyedPaths().edited,
+  )
+}

--- a/src/hasura/migration-table-change.ts
+++ b/src/hasura/migration-table-change.ts
@@ -61,6 +61,11 @@ export const migrationTableChange = (params: {
           if (isAddPrimaryKeyStatement) {
             warn('Found Hasura migration adding a primary key', filePath)
           }
+
+          const isAddUniqueConstraintStatement = /ADD CONSTRAINT .+ (UNIQUE|PRIMARY KEY)/.test(statement)
+          if (isAddUniqueConstraintStatement) {
+            warn('Found Hasura migration adding a unique constraint', filePath)
+          }
         }),
         R.map(R.compose(R.toUpper, R.trim)),
         // @ts-expect-error -- TS mistakenly identify "R.identity" type as "<T>(val: T): val is T" instead of "<T>(val: T): T"

--- a/src/hasura/migration-table-change.ts
+++ b/src/hasura/migration-table-change.ts
@@ -7,7 +7,9 @@ import * as R from 'ramda'
  * If present, warns in case of:
  * - rename of a field;
  * - removal of a field;
- * - "not null" restrictions on the existing field.
+ * - "not null" restrictions on the existing field;
+ * - primary key was added;
+ * - unique constraint was introduced.
  *
  * @param danger Danger instance
  * @param warn Danger warn function


### PR DESCRIPTION
Closes PLA-96.

The rule warns if a Hasura migration (changing a table, a view or a materialised view) introduces:
- unique index;
- rename of a field;
- removal of a field;
- "Not null" restrictions on an existing field;
- addition of a primary key.