### PR TITLE
Add excludeComponents prop to react dir name rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ but instead should be in dash case;
 - Use "-" (not "_") in non-component dir names.
 
 Additional notes:
-- a React component is defined as a function expression wrapped with `memo`;
+- a React component is defined as a function expression wrapped with `memo` located in an `index.tsx` file;
 - files within `__tests__` and `__mocks__` folders are ignored.
 
 ```typescript
@@ -139,6 +139,11 @@ react.dirNameRestrictions({
   danger,
   fail,
   includePaths: ['src/'],
+  /*
+   * The index page of a nextjs app does not follow the rule.
+   * We cannot use excludePaths here, since the excludePaths would exclude all descendants of a path.
+   */
+  excludeComponents: ['src/pages'],
 })
 ```
 

--- a/src/react/dir-name-restrictions.ts
+++ b/src/react/dir-name-restrictions.ts
@@ -2,6 +2,13 @@ import * as R from 'ramda'
 import {RuleParamsBase} from './types'
 import {filterPaths, getUniquePaths, isReactComponentFolder} from './utils'
 
+type RuleParamsDirNameRestrictions = RuleParamsBase & {
+  /**
+   * Components to exclude (a component is a folder with an "index.tsx" file, therefore only the folder path is required).
+   */
+  excludeComponents?: Array<string>
+}
+
 /**
  * For all created/modified files traverses up through all containing folders
  * and requires the following rules to apply:
@@ -13,10 +20,12 @@ import {filterPaths, getUniquePaths, isReactComponentFolder} from './utils'
  * - Use "-" (not "_") in non-component dir names.
  * @param danger Danger instance
  * @param fail Danger fail function
+ * @param excludeComponents components to exclude
+ * (a component is a folder with an "index.tsx" file, therefore only the folder path is required)
  * @param excludePaths paths to exclude
  * @param includePaths paths to include
  */
-export const dirNameRestrictions = (params: RuleParamsBase): void => {
+export const dirNameRestrictions = (params: RuleParamsDirNameRestrictions): void => {
   R.compose(
     R.forEach((path: string) => {
       const {fail} = params
@@ -51,6 +60,7 @@ export const dirNameRestrictions = (params: RuleParamsBase): void => {
       }
     }),
 
+    R.filter(R.compose(R.not, R.includes(R.__, params.excludeComponents || []))),
     getUniquePaths,
     filterPaths,
   )(params)


### PR DESCRIPTION
When changes are done anywhere within "src/pages" in a nextjs app the file "src/pages/index.tsx" would trigger a warning because it exposes a component but does not follow the rule (not capitalised folder name).

The prop is named "excludeComponents" and represents an array of component paths to exclude. The rule defines a component as a folder with an `index.tsx` file that exports a react component. Consequently a component path always ends with `/index.tsx`. Thus the filename is redundant and the array of components need to include only the folder path (without trailing slash). A relevant description is added to the JSDoc comment of the rule.