### PR TITLE
Add typecheck command

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -9,12 +9,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: ottofeller/github-actions/npm-run@main
+      with:
+        node-version: 16
+        command: npm run typecheck
+
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - uses: ottofeller/github-actions/npm-run@main
       with:
         node-version: 16
@@ -23,9 +28,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - uses: ottofeller/github-actions/npm-run@main
       with:
         node-version: 16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,17 +18,25 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  typecheck:
+    name: Typecheck the code
+    needs: set-commit-hash
+    runs-on: ubuntu-latest
+    steps:
+    - uses: ottofeller/github-actions/npm-run@main
+      with:
+        ref: ${{ needs.set-commit-hash.outputs.commit_hash }}
+        node-version: 16
+        command: npm run typecheck
+
   lint:
     name: Lint the code
     needs: set-commit-hash
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        ref: ${{ needs.set-commit-hash.outputs.commit_hash }}
     - uses: ottofeller/github-actions/npm-run@main
       with:
+        ref: ${{ needs.set-commit-hash.outputs.commit_hash }}
         node-version: 16
         command: npm run lint
 
@@ -37,18 +45,15 @@ jobs:
     needs: set-commit-hash
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        ref: ${{ needs.set-commit-hash.outputs.commit_hash }}
     - uses: ottofeller/github-actions/npm-run@main
       with:
         node-version: 16
+        ref: ${{ needs.set-commit-hash.outputs.commit_hash }}
         command: npm run test
 
   publish-npm:
     name: Publish the release to NPM
-    needs: [set-commit-hash, lint, test]
+    needs: [set-commit-hash, typecheck, lint, test]
     runs-on: ubuntu-latest
     steps:
       - uses: ottofeller/github-actions/publish-npm@main

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "A set of Danger.js rules common applied in OttoFeller projects.",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rollup -c && tsc src/*.ts --declaration --allowJs --emitDeclarationOnly --esModuleInterop --outDir dist",
+    "build": "rollup -c && tsc --declaration --emitDeclarationOnly",
     "format": "ofmt src/",
     "lint": "ofmt --lint src/ && olint src/",
-    "test": "jest --no-cache"
+    "test": "jest --no-cache",
+    "typecheck": "tsc --noEmit"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Previously tsc was run only upon a build, thus missing on pull request checks.

Remove some tsc flags in the build command - they already exist in the tsconfig.

The CI workflows are corrected as well and brought into accordance with the latest npm-run action version.