### PR TITLE
Simplify logic of bumpPackageVersion rule

### DIFF
--- a/src/bump-package-version/index.ts
+++ b/src/bump-package-version/index.ts
@@ -5,6 +5,7 @@ import * as R from 'ramda'
  * Checks all @includePaths and in case of presence of edited files
  * requires version in `package.json` to be updated.
  * Parameter @restrictToBranches defines branches to run the check for.
+ * Parameter @excludePaths defines patterns to exclude from checking.
  */
 export const bumpPackageVersion = async (params: {
   danger: DangerDSLType
@@ -13,7 +14,7 @@ export const bumpPackageVersion = async (params: {
   includePaths: Array<string>
   restrictToBranches: Array<string>
 }) => {
-  if (!params.restrictToBranches.includes(params.danger.github.pr.base.ref)) {
+  if (!R.includes(params.danger.github.pr.base.ref, params.restrictToBranches)) {
     return
   }
 
@@ -23,28 +24,27 @@ export const bumpPackageVersion = async (params: {
     return
   }
 
-  const paths = R.compose(
-    R.reject(
-      R.anyPass(R.map<string, (list: string | readonly string[]) => boolean>(R.includes, params.excludePaths || [])),
-    ),
-    R.filter(R.anyPass(R.map(R.includes, params.includePaths))),
-  )(files.getKeyedPaths().edited) as string[]
-
-  const failedPaths: Array<string> = []
-
   await Promise.all(
-    R.forEach(async (path) => {
-      const includePath = R.find(R.includes(R.__, path), params.includePaths)
+    R.forEach(async (includePath) => {
+      const includedFiles = params.danger.git.fileMatch(`${includePath}/**/*`)
+
+      // If there are no edits in the includePath the version should not be bumped
+      if (!includedFiles.edited) {
+        return
+      }
+
+      // Exclude paths containing any of the `excludePaths`.
+      const editedFiles = R.reject(R.includes(R.__, params.excludePaths || []), includedFiles.getKeyedPaths().edited)
+
+      if (!editedFiles.length) {
+        return
+      }
+
       const packageJson = await params.danger.git.JSONDiffForFile(`${includePath}/package.json`)
 
-      if (
-        includePath &&
-        !R.find(R.equals(includePath), failedPaths) &&
-        (!packageJson || !packageJson.version || packageJson.version.after === packageJson.version.before)
-      ) {
+      if (!packageJson || !packageJson.version || packageJson.version.after === packageJson.version.before) {
         params.fail(`The version in package.json must be updated in ${includePath}`)
-        failedPaths.push(includePath)
       }
-    }, paths),
+    }, params.includePaths),
   )
 }


### PR DESCRIPTION
Remove unnecessary filtering of edited paths. Remove caching of failed includePaths. Switch back to traversing includePaths array instead of all edited paths.

Closes PLA-133.